### PR TITLE
Aborting instead of removing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-valid8",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A simple form validation package made for Vue.js.",
   "main": "scripts/index",
   "repository": {

--- a/scripts/validation.js
+++ b/scripts/validation.js
@@ -74,7 +74,7 @@ export async function validateAll (scope) {
         fieldsToValidate = Object.keys(fields);
     }
 
-    const promise = new Promise((resolve) => {
+    await new Promise((resolve) => {
         fieldsToValidate.forEach((field, index, array) => {
             document.getElementsByName(field)[0]
                 .dispatchEvent(new Event('input'));
@@ -86,8 +86,6 @@ export async function validateAll (scope) {
                 resolve();
         });
     });
-
-    await promise;
     
     return !fieldsToValidate.map((field) => typeof fields[field] === 'string')
         .includes(true);


### PR DESCRIPTION
Now aborting the event listener instead of attempting to remove it. This way, it will be removed and won't fire multiple times. This will also remove it from being utilized with old masking/validation states.